### PR TITLE
Fix decoding of url-encoded relative paths

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -337,7 +337,7 @@ ipc.listen(ipc.messages.fileOpen, async file => {
             try {
                 statusOnMouseOver(link, decodeURI(target))
             } catch (err) {
-                log.error(err.message)
+                log.error(err)
                 statusOnMouseOver(link, target)
             }
         }

--- a/app/index.js
+++ b/app/index.js
@@ -336,7 +336,8 @@ ipc.listen(ipc.messages.fileOpen, async file => {
             navigation.registerLink(link, target, documentDirectory)
             try {
                 statusOnMouseOver(link, decodeURI(target))
-            } catch {
+            } catch (err) {
+                log.error(err.message)
                 statusOnMouseOver(link, target)
             }
         }

--- a/app/index.js
+++ b/app/index.js
@@ -329,12 +329,16 @@ ipc.listen(ipc.messages.fileOpen, async file => {
         populateToc(content, "toc")
     }
 
-    // Alter local references to be relativ to the document
+    // Alter local references to be relative to the document
     alterTags("a", link => {
         const target = link.getAttribute("href")
         if (target) {
             navigation.registerLink(link, target, documentDirectory)
-            statusOnMouseOver(link, target)
+            try {
+                statusOnMouseOver(link, decodeURI(target))
+            } catch {
+                statusOnMouseOver(link, target)
+            }
         }
     })
     alterTags("img", image => {

--- a/app/lib/file.js
+++ b/app/lib/file.js
@@ -59,7 +59,7 @@ exports.transformRelativePath = (documentDirectory, filePath) => {
     try {
         return path.join(documentDirectory, decodeURIComponent(filePath)).replace("#", "%23")
     } catch (err) {
-        log.error(err.message)
+        log.error(err)
         return path.join(documentDirectory, filePath).replace("#", "%23")
     }
 }

--- a/app/lib/file.js
+++ b/app/lib/file.js
@@ -1,4 +1,5 @@
 const fs = require("fs")
+const path = require("path")
 
 const common = require("./common")
 const log = require("./log")
@@ -53,7 +54,13 @@ exports.extractFileEnding = filePath => {
     return parts.length > 1 ? parts.at(-1).toLowerCase() : ""
 }
 
-exports.transformRelativePath = (documentDirectory, filePath) =>
-    path.join(documentDirectory, filePath).replace("#", "%23")
+exports.transformRelativePath = (documentDirectory, filePath) => {
+    // DecodeURIComponent throws URIError on malformed escapes (e.g %GG or %), hence the try/catch
+    try {
+        return path.join(documentDirectory, decodeURIComponent(filePath)).replace("#", "%23")
+    } catch {
+        return path.join(documentDirectory, filePath).replace("#", "%23")
+    }
+}
 
 exports.isAbsolutePath = filePath => Boolean(filePath.match(/^(\S\:)?(\\|\/)/))

--- a/app/lib/file.js
+++ b/app/lib/file.js
@@ -58,7 +58,8 @@ exports.transformRelativePath = (documentDirectory, filePath) => {
     // DecodeURIComponent throws URIError on malformed escapes (e.g %GG or %), hence the try/catch
     try {
         return path.join(documentDirectory, decodeURIComponent(filePath)).replace("#", "%23")
-    } catch {
+    } catch (err) {
+        log.error(err.message)
         return path.join(documentDirectory, filePath).replace("#", "%23")
     }
 }

--- a/test/libFile.spec.js
+++ b/test/libFile.spec.js
@@ -51,4 +51,41 @@ describe('Library "file"', () => {
             }
         })
     })
+
+    describe("file.transformRelativePath", () => {
+        it("decodes URL-encoded relative paths", () => {
+            assert.strictEqual(
+                file.transformRelativePath("C:\\docs\\计划", "../%E8%AF%81%E6%8D%AE/note.md"),
+                path.join("C:\\docs\\计划", "../证据/note.md"),
+            )
+        })
+
+        it("decodes Unicode filenames", () => {
+            assert.strictEqual(
+                file.transformRelativePath("C:\\docs", "./%E8%AE%A1%E5%88%92.md"),
+                path.join("C:\\docs", "./计划.md"),
+            )
+        })
+
+        it("decodes spaces in relative paths", () => {
+            assert.strictEqual(
+                file.transformRelativePath("C:\\docs", "../My%20Docs/file.md"),
+                path.join("C:\\docs", "../My Docs/file.md"),
+            )
+        })
+
+        it("keeps malformed relative paths unchanged", () => {
+            assert.strictEqual(
+                file.transformRelativePath("C:\\docs", "../%GG/file.md"),
+                path.join("C:\\docs", "../%GG/file.md"),
+            )
+        })
+
+        it("keeps ASCII relative paths unchanged", () => {
+            assert.strictEqual(
+                file.transformRelativePath("C:\\docs", "../other.md"),
+                path.join("C:\\docs", "../other.md"),
+            )
+        })
+    })
 })


### PR DESCRIPTION
## Summary

This PR fixes navigation to local resources whose relative paths contain url-encoded characters (e.g. chinese filenames/directories).

Previously, relative paths were resolved without being decoded first, causing links such as `../证据/note.md` to fail after being url-encoded.

### Changes

* Decode url-encoded relative paths before resolving them to local filesystem paths.
* Display decoded URLs in the status bar for improved readability.
* Preserve existing behavior for external URLs (HTTP(S), `mailto:`, etc.).

### Tests

Added tests covering:

* url-encoded Unicode directory names.
* url-encoded spaces.
* Malformed encoded paths (left unchanged).
* ASCII-only relative paths (unchanged).

This fixes the reported issue with navigating to Markdown files whose paths contain non-ASCII characters while preserving existing behavior for web links.


Fixes #85